### PR TITLE
new validation rule, fixed error update item if not providing chart_of_account_id

### DIFF
--- a/app/Http/Requests/Master/Item/StoreItemRequest.php
+++ b/app/Http/Requests/Master/Item/StoreItemRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Master\Item;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\ValidationRule;
 
 class StoreItemRequest extends FormRequest
 {
@@ -29,9 +30,15 @@ class StoreItemRequest extends FormRequest
     public function rules()
     {
         return [
-            'chart_of_account_id' => 'required',
+            'name' => 'required|string',
+            'chart_of_account_id' => ValidationRule::foreignKey('chart_of_accounts'),
+            'code' => 'bail|nullable|string|unique:items,code',
+            'barcode' => 'bail|nullable|string|unique:items,barcode',
+            'stock_reminder' => 'numeric|min:0',
+            'taxable' => 'boolean',
             'units' => 'required|array',
             'groups' => 'array',
+            // TODO each units and groups field
         ];
     }
 }

--- a/app/Http/Requests/Master/Item/StoreManyItemRequest.php
+++ b/app/Http/Requests/Master/Item/StoreManyItemRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Master\Item;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\ValidationRule;
 
 class StoreManyItemRequest extends FormRequest
 {
@@ -28,9 +29,11 @@ class StoreManyItemRequest extends FormRequest
     public function rules()
     {
         return [
-            'items.*.chart_of_account_id' => 'required',
+            'items.*.chart_of_account_id' => ValidationRule::foreignKey('chart_of_accounts'),
             'items.*.units' => 'required|array',
-            'items.*.groups' => 'array',
+            'items.*.groups' => 'nullable|array',
+
+            // TODO each units and groups fields
         ];
     }
 }

--- a/app/Http/Requests/Master/Item/UpdateItemRequest.php
+++ b/app/Http/Requests/Master/Item/UpdateItemRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Master\Item;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\ValidationRule;
 
 class UpdateItemRequest extends FormRequest
 {
@@ -24,9 +25,16 @@ class UpdateItemRequest extends FormRequest
     public function rules()
     {
         return [
-            'chart_of_account_id' => 'required',
-            'units' => 'required|array',
-            'groups' => 'array',
+            'name' => 'string',
+            'chart_of_account_id' => ValidationRule::foreignKeyOptional('chart_of_accounts'),
+            'code' => 'bail|nullable|string|unique:items,code',
+            'barcode' => 'bail|nullable|string|unique:items,barcode',
+            'stock_reminder' => 'numeric|min:0',
+            'taxable' => 'boolean',
+            'units' => 'array',
+            'groups' => 'nullable|array',
+
+            // TODO each units and groups field
         ];
     }
 }

--- a/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/StorePurchaseInvoiceRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/StorePurchaseInvoiceRequest.php
@@ -47,7 +47,7 @@ class StorePurchaseInvoiceRequest extends FormRequest
             'items.*.price' => ValidationRule::price(),
             'items.*.unit' => ValidationRule::unit(),
             'items.*.converter' => ValidationRule::converter(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulesPurchaseInvoiceServices = [
@@ -55,7 +55,7 @@ class StorePurchaseInvoiceRequest extends FormRequest
             'services.*.service_name' => 'required|string',
             'services.*.quantity' => ValidationRule::quantity(),
             'services.*.price' => ValidationRule::price(),
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($rulesForm, $rulesPurchaseInvoice, $rulesPurchaseInvoiceItems, $rulesPurchaseInvoiceServices);

--- a/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/UpdatePurchaseInvoiceRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/UpdatePurchaseInvoiceRequest.php
@@ -46,7 +46,7 @@ class UpdatePurchaseInvoiceRequest extends FormRequest
             'items.*.price' => ValidationRule::price(),
             'items.*.unit' => ValidationRule::unit(),
             'items.*.converter' => ValidationRule::converter(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulesPurchaseInvoiceServices = [
@@ -54,7 +54,7 @@ class UpdatePurchaseInvoiceRequest extends FormRequest
             'services.*.service_name' => 'required|string',
             'services.*.quantity' => ValidationRule::quantity(),
             'services.*.price' => ValidationRule::price(),
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($rulesForm, $rulesPurchaseInvoice, $rulesPurchaseInvoiceItems, $rulesPurchaseInvoiceServices);

--- a/app/Http/Requests/Purchase/PurchaseOrder/PurchaseOrder/StorePurchaseOrderRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseOrder/PurchaseOrder/StorePurchaseOrderRequest.php
@@ -28,12 +28,12 @@ class StorePurchaseOrderRequest extends FormRequest
 
         $rulesPurchaseOrder = [
             
-            'purchase_request_id' => ValidationRule::optionalForeignKey('purchase_requests'),
-            'purchase_contract_id' => ValidationRule::optionalForeignKey('purchase_contracts'),
+            'purchase_request_id' => ValidationRule::foreignKeyNullable('purchase_requests'),
+            'purchase_contract_id' => ValidationRule::foreignKeyNullable('purchase_contracts'),
 
             'supplier_id' => ValidationRule::foreignKey('suppliers'),
             'supplier_name' => 'required|string',
-            'warehouse_id' => ValidationRule::optionalForeignKey('warehouses'),
+            'warehouse_id' => ValidationRule::foreignKeyNullable('warehouses'),
             'eta' => 'date',
             'cash_only' => 'boolean',
             'need_down_payment' => ValidationRule::needDownPayment(),
@@ -48,7 +48,7 @@ class StorePurchaseOrderRequest extends FormRequest
         ];
 
         $rulesPurchaseOrderItems = [
-            'items.*.purchase_request_item_id' => ValidationRule::optionalForeignKey('items'),
+            'items.*.purchase_request_item_id' => ValidationRule::foreignKeyNullable('items'),
             'items.*.item_id' => ValidationRule::foreignKey('items'),
             'items.*.item_name' => 'required|string',
             'items.*.quantity' => ValidationRule::quantity(),
@@ -58,11 +58,11 @@ class StorePurchaseOrderRequest extends FormRequest
             'items.*.taxable' => 'boolean',
             'items.*.unit' => ValidationRule::unit(),
             'items.*.converter' => ValidationRule::converter(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulesPurchaseOrderServices = [
-            'services.*.purchase_request_item_id' => ValidationRule::optionalForeignKey('services'),
+            'services.*.purchase_request_item_id' => ValidationRule::foreignKeyNullable('services'),
             'services.*.service_id' => ValidationRule::foreignKey('services'),
             'services.*.service_name' => 'required|string',
             'services.*.quantity' => ValidationRule::quantity(),
@@ -70,7 +70,7 @@ class StorePurchaseOrderRequest extends FormRequest
             'services.*.discount_percent' => ValidationRule::discountPercent(),
             'services.*.discount_value' => ValidationRule::discountValue(),
             'services.*.taxable' => 'boolean',
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($rulesForm, $rulesPurchaseOrder, $rulesPurchaseOrderItems, $rulesPurchaseOrderServices);

--- a/app/Http/Requests/Purchase/PurchaseOrder/PurchaseOrder/UpdatePurchaseOrderRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseOrder/PurchaseOrder/UpdatePurchaseOrderRequest.php
@@ -26,12 +26,12 @@ class UpdatePurchaseOrderRequest extends FormRequest
         $rulesForm = ValidationRule::form();
 
         $rulesPurchaseOrder = [
-            'purchase_request_id' => ValidationRule::optionalForeignKey('purchase_requests'),
-            'purchase_contract_id' => ValidationRule::optionalForeignKey('purchase_contracts'),
+            'purchase_request_id' => ValidationRule::foreignKeyNullable('purchase_requests'),
+            'purchase_contract_id' => ValidationRule::foreignKeyNullable('purchase_contracts'),
 
             'supplier_id' => ValidationRule::foreignKey('suppliers'),
             'supplier_name' => 'required|string',
-            'warehouse_id' => ValidationRule::optionalForeignKey('warehouses'),
+            'warehouse_id' => ValidationRule::foreignKeyNullable('warehouses'),
             'eta' => 'date',
             'cash_only' => 'boolean',
             'need_down_payment' => ValidationRule::needDownPayment(),
@@ -46,7 +46,7 @@ class UpdatePurchaseOrderRequest extends FormRequest
         ];
 
         $rulesPurchaseOrderItems = [
-            'items.*.purchase_request_item_id' => ValidationRule::optionalForeignKey('items'),
+            'items.*.purchase_request_item_id' => ValidationRule::foreignKeyNullable('items'),
             'items.*.item_id' => ValidationRule::foreignKey('items'),
             'items.*.item_name' => 'required|string',
             'items.*.quantity' => ValidationRule::quantity(),
@@ -56,11 +56,11 @@ class UpdatePurchaseOrderRequest extends FormRequest
             'items.*.taxable' => 'boolean',
             'items.*.unit' => ValidationRule::unit(),
             'items.*.converter' => ValidationRule::converter(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulesPurchaseOrderServices = [
-            'services.*.purchase_request_item_id' => ValidationRule::optionalForeignKey('services'),
+            'services.*.purchase_request_item_id' => ValidationRule::foreignKeyNullable('services'),
             'services.*.service_id' => ValidationRule::foreignKey('services'),
             'services.*.service_name' => 'required|string',
             'services.*.quantity' => ValidationRule::quantity(),
@@ -68,7 +68,7 @@ class UpdatePurchaseOrderRequest extends FormRequest
             'services.*.discount_percent' => ValidationRule::discountPercent(),
             'services.*.discount_value' => ValidationRule::discountValue(),
             'services.*.taxable' => 'boolean',
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($rulesForm, $rulesPurchaseOrder, $rulesPurchaseOrderItems, $rulesPurchaseOrderServices);

--- a/app/Http/Requests/Purchase/PurchaseReceive/PurchaseReceive/StorePurchaseReceiveRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseReceive/PurchaseReceive/StorePurchaseReceiveRequest.php
@@ -30,7 +30,7 @@ class StorePurchaseReceiveRequest extends FormRequest
             'supplier_id' => ValidationRule::foreignKey('suppliers'),
             'supplier_name' => 'required|string',
             'warehouse_id' => ValidationRule::foreignKey('warehouses'),
-            'purchase_order_id' => ValidationRule::optionalForeignKey('purchase_orders'),
+            'purchase_order_id' => ValidationRule::foreignKeyNullable('purchase_orders'),
 
             'items' => 'required_without:services|array',
             'services' => 'required_without:items|array',
@@ -43,7 +43,7 @@ class StorePurchaseReceiveRequest extends FormRequest
             'items.*.quantity' => ValidationRule::quantity(),
             'items.*.unit' => ValidationRule::quantity(),
             'items.*.converter' => ValidationRule::quantity(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulePurchaseReceiveServices = [
@@ -51,7 +51,7 @@ class StorePurchaseReceiveRequest extends FormRequest
             'services.*.service_name' => 'required|string',
             'services.*.purchase_order_service_id' => ValidationRule::foreignKey('purchase_order_services'),
             'services.*.quantity' => ValidationRule::quantity(),
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($ruleForm, $rulePurchaseReceive, $rulePurchaseReceiveItems, $rulePurchaseReceiveServices);

--- a/app/Http/Requests/Purchase/PurchaseReceive/PurchaseReceive/UpdatePurchaseReceiveRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseReceive/PurchaseReceive/UpdatePurchaseReceiveRequest.php
@@ -29,7 +29,7 @@ class UpdatePurchaseReceiveRequest extends FormRequest
             'supplier_id' => ValidationRule::foreignKey('suppliers'),
             'supplier_name' => 'required|string',
             'warehouse_id' => ValidationRule::foreignKey('warehouses'),
-            'purchase_order_id' => ValidationRule::optionalForeignKey('purchase_orders'),
+            'purchase_order_id' => ValidationRule::foreignKeyNullable('purchase_orders'),
 
             'items' => 'required_without:services|array',
             'services' => 'required_without:items|array',
@@ -42,7 +42,7 @@ class UpdatePurchaseReceiveRequest extends FormRequest
             'items.*.quantity' => ValidationRule::quantity(),
             'items.*.unit' => ValidationRule::quantity(),
             'items.*.converter' => ValidationRule::quantity(),
-            'items.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'items.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         $rulePurchaseReceiveServices = [
@@ -50,7 +50,7 @@ class UpdatePurchaseReceiveRequest extends FormRequest
             'services.*.service_name' => 'required|string',
             'services.*.purchase_order_service_id' => ValidationRule::foreignKey('purchase_order_services'),
             'services.*.quantity' => ValidationRule::quantity(),
-            'services.*.allocation_id' => ValidationRule::optionalForeignKey('allocations'),
+            'services.*.allocation_id' => ValidationRule::foreignKeyNullable('allocations'),
         ];
 
         return array_merge($ruleForm, $rulePurchaseReceive, $rulePurchaseReceiveItems, $rulePurchaseReceiveServices);

--- a/app/Http/Requests/ValidationRule.php
+++ b/app/Http/Requests/ValidationRule.php
@@ -24,9 +24,29 @@ class ValidationRule {
     return 'numeric|min:0';
   }
   
+  /**
+   * User must provide this column, and can not be null value
+   */
   public static function foreignKey(String $table, String $column = 'id')
   {
     return "bail|required|integer|min:0|exists:tenant.$table,$column";
+  }
+  
+  /**
+   * User can skip this column from input or provide null value to this column
+   */
+  public static function foreignKeyNullable(String $table, String $column = 'id')
+  {
+    return "bail|nullable|integer|min:0|exists:tenant.$table,$column";
+  }
+
+  /**
+   * User can skip this column from input, but can not provide null value
+   * Useful for update validation where user do not want to change not nullable column
+   */
+  public static function foreignKeyOptional(String $table, String $column = 'id')
+  {
+    return "bail|integer|min:0|exists:tenant.$table,$column";
   }
 
   public static function form()
@@ -37,11 +57,6 @@ class ValidationRule {
       'increment_group' => 'required|integer',
       'approver_id' => self::foreignKey('users'),
     ];
-  }
-  
-  public static function optionalForeignKey(String $table, String $column = 'id')
-  {
-    return "bail|nullable|integer|min:0|exists:tenant.$table,$column";
   }
 
   public static function quantity()


### PR DESCRIPTION
required = must be provided
optional = can be not provided, but the value must not null
nullable = can be not provided, the value itself can null