### PR TITLE
fixed error polymorphic service provider

### DIFF
--- a/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/UpdatePurchaseInvoiceRequest.php
+++ b/app/Http/Requests/Purchase/PurchaseInvoice/PurchaseInvoice/UpdatePurchaseInvoiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Purchase\PurchaseInvoice\PurchaseInvoice;
 
+use App\Http\Requests\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdatePurchaseInvoiceRequest extends FormRequest

--- a/app/Providers/PolymorphicTypeServiceProvider.php
+++ b/app/Providers/PolymorphicTypeServiceProvider.php
@@ -9,7 +9,7 @@ use App\Model\Purchase\PurchaseContract\PurchaseContract;
 use App\Model\Purchase\PurchaseDownPayment\PurchaseDownPayment;
 use App\Model\Purchase\PurchaseInvoice\PurchaseInvoice;
 use App\Model\Purchase\PurchaseOrder\PurchaseOrder;
-use App\Model\Purchase\PurchaseReturn\SalesReturn;
+use App\Model\Purchase\PurchaseReturn\PurchaseReturn;
 use App\Model\Sales\SalesContract\SalesContract;
 use App\Model\Sales\SalesDownPayment\SalesDownPayment;
 use App\Model\Sales\SalesInvoice\SalesInvoice;
@@ -35,7 +35,7 @@ class PolymorphicTypeServiceProvider extends ServiceProvider
             'PurchaseContract' => PurchaseContract::class,
             'PurchaseDownPayment' => PurchaseDownPayment::class,
             'PurchaseInvoice' => PurchaseInvoice::class,
-            'PurchaseReturn' => SalesReturn::class,
+            'PurchaseReturn' => PurchaseReturn::class,
             'SalesOrder' => SalesOrder::class,
             'SalesContract' => SalesContract::class,
             'SalesDownPayment' => SalesDownPayment::class,


### PR DESCRIPTION
Cannot use App\Model\Sales\SalesReturn\SalesReturn as SalesReturn because the name is already in use