### PR TITLE
Handle duplicate data on Pin Point, sales visitation

### DIFF
--- a/app/Http/Controllers/Api/Plugin/PinPoint/InterestReasonController.php
+++ b/app/Http/Controllers/Api/Plugin/PinPoint/InterestReasonController.php
@@ -33,10 +33,14 @@ class InterestReasonController extends Controller
      */
     public function store(Request $request)
     {
-        $interestReason = new InterestReason;
-        $interestReason->fill($request->all());
-        $interestReason->save();
+        try {
+            $interestReason = new InterestReason;
+            $interestReason->name = str_clean($request->get("name"));
+            $interestReason->save();
 
-        return new ApiResource($interestReason);
+            return new ApiResource($interestReason);
+        } catch (\Exception $err) {
+            return response()->json(['message' => "Data exists!"], 400);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Plugin/PinPoint/NoInterestReasonController.php
+++ b/app/Http/Controllers/Api/Plugin/PinPoint/NoInterestReasonController.php
@@ -33,10 +33,14 @@ class NoInterestReasonController extends Controller
      */
     public function store(Request $request)
     {
-        $noInterestReason = new NoInterestReason;
-        $noInterestReason->fill($request->all());
-        $noInterestReason->save();
+        try {
+            $noInterestReason = new NoInterestReason;
+            $noInterestReason->name = str_clean($request->get("name"));
+            $noInterestReason->save();
 
-        return new ApiResource($noInterestReason);
+            return new ApiResource($noInterestReason);
+        } catch (\Exception $err) {
+            return response()->json(['message' => "Data exists!"], 400);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Plugin/PinPoint/SimilarProductController.php
+++ b/app/Http/Controllers/Api/Plugin/PinPoint/SimilarProductController.php
@@ -33,10 +33,14 @@ class SimilarProductController extends Controller
      */
     public function store(Request $request)
     {
-        $similarProduct = new SimilarProduct;
-        $similarProduct->fill($request->all());
-        $similarProduct->save();
+        try {
+            $similarProduct = new SimilarProduct;
+            $similarProduct->name = str_clean($request->get("name"));
+            $similarProduct->save();
 
-        return new ApiResource($similarProduct);
+            return new ApiResource($similarProduct);
+        } catch (\Exception $err) {
+            return response()->json(['message' => "Data exists!"], 400);
+        }
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -328,4 +328,18 @@ if (! function_exists('base64_to_jpeg')) {
 
         return $output_file;
     }
+
+
+    if (! function_exists('str_clean')) {
+        /**
+         * Log an object / array.
+         *
+         * @param $str
+         * @return string
+         */
+        function str_clean($str)
+        {   
+            return trim(preg_replace('/\s\s+/', ' ', str_replace("\n", " ", $str)));
+        }
+    }
 }

--- a/database/migrations/tenant/2021_12_27_031839_alter_similar_products_table_add_unique_indexing.php
+++ b/database/migrations/tenant/2021_12_27_031839_alter_similar_products_table_add_unique_indexing.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterSimilarProductsTableAddUniqueIndexing extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pin_point_similar_products', function (Blueprint $table) {
+            $table->unique("name");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/tenant/2021_12_27_032029_alter_interest_reason_table_add_unique_indexing.php
+++ b/database/migrations/tenant/2021_12_27_032029_alter_interest_reason_table_add_unique_indexing.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterInterestReasonTableAddUniqueIndexing extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pin_point_interest_reasons', function (Blueprint $table) {
+            $table->unique("name");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/tenant/2021_12_27_032041_alter_no_interest_reason_table_add_unique_indexing.php
+++ b/database/migrations/tenant/2021_12_27_032041_alter_no_interest_reason_table_add_unique_indexing.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterNoInterestReasonTableAddUniqueIndexing extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pin_point_no_interest_reasons', function (Blueprint $table) {
+            $table->unique("name");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/Feature/Http/Plugins/PinPoint/InterestReasonsTest.php
+++ b/tests/Feature/Http/Plugins/PinPoint/InterestReasonsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Http\Plugins\PinPoint;
+
+use Tests\TestCase;
+
+class InterestReasonsTest extends TestCase
+{
+    static $ENDPOINT = '/api/v1/plugin/pin-point/interest-reasons';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function create_interest_reasons()
+    {
+        $data = [
+            'name' => $this->faker->name,
+        ];
+
+        $response = $this->json('POST', self::$ENDPOINT, $data, [$this->headers]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('pin_point_interest_reasons', $data, 'tenant');
+    }
+
+    /** @test */
+    public function duplicate_interest_reasons()
+    {
+        $this->json('POST', self::$ENDPOINT, ['name' => 'duplicate'], [$this->headers]);
+        $response2 = $this->json('POST', self::$ENDPOINT, ['name' => 'duplicate'], [$this->headers]);
+
+        $response2->assertStatus(400);
+    }
+
+}

--- a/tests/Feature/Http/Plugins/PinPoint/NoInterestReasonsTest.php
+++ b/tests/Feature/Http/Plugins/PinPoint/NoInterestReasonsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Http\Plugins\PinPoint;
+
+use Tests\TestCase;
+
+class NoInterestReasonsTest extends TestCase
+{
+    static $ENDPOINT = '/api/v1/plugin/pin-point/no-interest-reasons';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function create_no_interest_reasons()
+    {
+        $data = [
+            'name' => $this->faker->name,
+        ];
+
+        $response = $this->json('POST', self::$ENDPOINT, $data, [$this->headers]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('pin_point_no_interest_reasons', $data, 'tenant');
+    }
+
+    /** @test */
+    public function duplicate_no_interest_reasons()
+    {
+        $this->json('POST', self::$ENDPOINT, ['name' => 'duplicate'], [$this->headers]);
+        $response2 = $this->json('POST', self::$ENDPOINT, ['name' => 'duplicate'], [$this->headers]);
+
+        $response2->assertStatus(400);
+    }
+
+}

--- a/tests/Feature/Http/Plugins/PinPoint/SimilarProductTest.php
+++ b/tests/Feature/Http/Plugins/PinPoint/SimilarProductTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Http\Plugins\PinPoint;
+
+use Tests\TestCase;
+
+class SimilarProductTest extends TestCase
+{
+    static $ENDPOINT = '/api/v1/plugin/pin-point/similar-products';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function create_similar_product()
+    {
+        $data = [
+            'name' => $this->faker->name,
+        ];
+
+        $response = $this->json('POST', self::$ENDPOINT, $data, [$this->headers]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('pin_point_similar_products', $data, 'tenant');
+    }
+
+    /** @test */
+    public function duplicate_similar_product()
+    {
+        $this->json('POST', self::$ENDPOINT, ['name' => 'similar'], [$this->headers]);
+        $response2 = $this->json('POST', self::$ENDPOINT, ['name' => 'similar'], [$this->headers]);
+
+        $response2->assertStatus(400);
+    }
+
+}

--- a/tests/Unit/HelperTest.php
+++ b/tests/Unit/HelperTest.php
@@ -49,4 +49,13 @@ class HelperTest extends TestCase
 
         $this->assertStringContainsString('2019-01-10 00:00:00', $date);
     }
+
+    /** @test */
+    public function str_clean_test()
+    {
+        $str = "  with  two  spaces  ";
+        $expected = "with two spaces";
+
+        $this->assertEquals($expected, str_clean($str));
+    }
 }


### PR DESCRIPTION
Notes: Please run these queries to clean duplicate data
DELETE a
FROM pin_point_similar_products a
LEFT JOIN pin_point_similar_products b
ON a.name = b.name
AND a.id > b.id
where b.id is not null;

DELETE a
FROM pin_point_interest_reasons a
LEFT JOIN pin_point_interest_reasons b
ON a.name = b.name
AND a.id > b.id
where b.id is not null;

DELETE a
FROM pin_point_no_interest_reasons a
LEFT JOIN pin_point_no_interest_reasons b
ON a.name = b.name
AND a.id > b.id
where b.id is not null;

----------------------;
Run this migration script to create unique indexing on field name

php artisan migrate --path=database/migrations/tenant --database=tenant
*Please run above queries before run this script to avoid error