### PR TITLE
fixed required if validation if not draft

### DIFF
--- a/app/Http/Requests/Plugin/Study/StudySheetStoreRequest.php
+++ b/app/Http/Requests/Plugin/Study/StudySheetStoreRequest.php
@@ -24,21 +24,38 @@ class StudySheetStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'started_at' => 'required_if:is_draft,false',
-            'ended_at' => 'required_if:is_draft,false',
+            'started_at' => 'required_if:is_draft,0',
+            'ended_at' => 'required_if:is_draft,0',
             'photo' => 'nullable|image',
             'audio' => 'nullable|mimetypes:audio/*',
             'video' => 'nullable|mimetypes:video/*',
-            'subject_id' => 'required_if:is_draft,false|exists:tenant.study_subjects,id',
+            'subject_id' => 'required_if:is_draft,0|exists:tenant.study_subjects,id',
             'institution' => 'nullable|string|max:180',
             'teacher' => 'nullable|string|max:180',
-            'competency' => 'required_if:is_draft,false|string|max:180',
-            'learning_goals' => 'required_if:is_draft,false|string|max:180',
+            'competency' => 'required_if:is_draft,0|string|max:180',
+            'learning_goals' => 'required_if:is_draft,0|string|max:180',
             'activities' => 'nullable|string|max:180',
             'grade' => 'nullable|integer|max:100',
-            'behavior' => 'required_if:is_draft,false|string|max:1|in:A,B,C',
+            'behavior' => 'required_if:is_draft,0|string|max:1|in:A,B,C',
             'remarks' => 'nullable|string|max:180',
             'is_draft' => 'required|boolean',
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'started_at.required_if' => __('validation.required'),
+            'ended_at.required_if' => __('validation.required'),
+            'subject_id.required_if' => __('validation.required'),
+            'competency.required_if' => __('validation.required'),
+            'learning_goals.required_if' => __('validation.required'),
+            'behavior.required_if' => __('validation.required'),
         ];
     }
 }

--- a/tests/Feature/Http/Plugins/Study/StudySheetStoreRequestTest.php
+++ b/tests/Feature/Http/Plugins/Study/StudySheetStoreRequestTest.php
@@ -52,39 +52,15 @@ class StudySheetStoreRequestTest extends StudyTestCase
     public function test_required_if_not_draft()
     {
         $form = [
-            'is_draft' => false,
+            'is_draft' => 0,
         ];
         $errors = [
-            'started_at' => __('validation.required_if', [
-                'attribute' => 'started at',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
-            'ended_at' => __('validation.required_if', [
-                'attribute' => 'ended at',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
-            'subject_id' => __('validation.required_if', [
-                'attribute' => 'subject id',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
-            'competency' => __('validation.required_if', [
-                'attribute' => 'competency',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
-            'learning_goals' => __('validation.required_if', [
-                'attribute' => 'learning goals',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
-            'behavior' => __('validation.required_if', [
-                'attribute' => 'behavior',
-                'other' => 'is draft',
-                'value' => 'false'
-            ]),
+            'started_at' => __('validation.required', ['attribute' => 'started at']),
+            'ended_at' => __('validation.required', ['attribute' => 'ended at']),
+            'subject_id' => __('validation.required', ['attribute' => 'subject id']),
+            'competency' => __('validation.required', ['attribute' => 'competency']),
+            'learning_goals' => __('validation.required', ['attribute' => 'learning goals']),
+            'behavior' => __('validation.required', ['attribute' => 'behavior']),
         ];
         
         $this->jsonPost($form)->assertJsonValidationErrors($errors);


### PR DESCRIPTION
Previously, it uses required_if:is_draft,false
But because the frontend can save files, it uses multipart/form-data which translates the false to "false" and fail the `is_draft => boolean` validation.
As a workaround, the frontend sends '0' instead of 'false', and the validation is_draft => boolean works as expected.

But because it expects is_draft to be '0', the `required_if:is_draft,false` fails. Changed the validation rule and its test to `required_if:is_draft,0`

Also updated the error message
```diff
- The competency field is required when is draft is 0.
+ The competency field is required.
```
